### PR TITLE
ignoring mailto anchors to avoid crashing the program

### DIFF
--- a/app/commands/articles/scrape.rb
+++ b/app/commands/articles/scrape.rb
@@ -20,6 +20,10 @@ module Articles
     def collect_all_articles
       for page in @pages
         Rails.logger.info "Found page: " + page.to_s unless quiet
+        if page.to_s.include? "mailto"
+          Rails.logger.warn "Ignoring 'mailto' anchor"
+          next
+        end
         @pages + collect_all_articles_from_page(page)
       end
     end


### PR DESCRIPTION
Adding an exception block to avoid crash when scraper gets `mailto` links.